### PR TITLE
Allow MGE to work with 3D mass profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,21 @@ Additional Jax friendly mass and light profiles for gravitational lensing.
 While these profiles were originally designed for use with [Herculens](https://github.com/Herculens/herculens), they should be general enough to be used in other Jax based modeling software.
 
 ## Light Profiles
-- `multi_gaussian_light.MultiGaussian`: Sum of multiple (vectorized) circular Gaussian profiles
-- `multi_gaussian_light.MultiGaussianEllipse`: Sum of multiple (vectorized) elliptical Gaussian profiles
+- `multi_gaussian_light.MultiGaussian`: Sum of multiple (vectorized) circular Gaussian profiles [`MULTI_GAUSSIAN`]
+- `multi_gaussian_light.MultiGaussianEllipse`: Sum of multiple (vectorized) elliptical Gaussian profiles [`MULTI_GAUSSIAN_ELLIPSE`]
 
 ## Mass Profiles
-- `gaussian_kappa.GaussianKappa`: Single circular Gaussian convergence profile
-- `gaussian_ellipse_kappa.GaussianEllipseKappa`: Single elliptical Gaussian convergence profile
-- `multi_gaussian_ellipse_kappa.MultiGaussianEllipseKappa`: Sum of multiple (vectorized) elliptical Gaussian convergence profiles
-- `MGE.MGE`: A multi-gaussian-expansion of a given radial convergence profile
-- `NFW.NFW`: circular NFW profile
-- `NFW.TNFW`: circular Truncated NFW profile
-- `NFW_ellipse_kappa.NFWEllipseKappa`: Elliptical NFW convergence profile
-- `Sersic_ellipse_kappa.SersicEllipseKappa`: Elliptical Sersic convergence profile
+- `gaussian_kappa.GaussianKappa`: Single circular Gaussian convergence profile [`GAUSSIAN_KAPPA`]
+- `gaussian_ellipse_kappa.GaussianEllipseKappa`: Single elliptical Gaussian convergence profile [`GAUSSIAN_ELLIPSE_KAPPA`]
+- `multi_gaussian_ellipse_kappa.MultiGaussianEllipseKappa`: Sum of multiple (vectorized) elliptical Gaussian convergence profiles [`MULTI_GAUSSIAN_ELLIPSE_KAPPA`]
+- `MGE.MGE`: A multi-gaussian-expansion of a given radial scaled mass profile
+- `NFW.NFW`: circular NFW profile [`NFW`]
+- `NFW.TNFW`: circular Truncated NFW profile [`TNFW`]
+- `NFW_ellipse_kappa.NFWEllipseKappa`: Elliptical NFW convergence profile [`NFW_ELLIPSE_KAPPA`]
+- `TNFW_ellipse_kappa.TNFWEllipseKappa`: Elliptical Truncated NFW convergence profile [`TNFW_ELLIPSE_KAPPA`]
+- `CuspyNFW_ellipse_kappa.CuspyNFWEllipseKappa`: Elliptical cuspy NFW convergence profile [`CUSPY_NFW_ELLIPSE_KAPPA`]
+- `CuspyHalo_ellipse_kappa.CuspyNFWEllipseKappa`: Elliptical cuspy halo convergence profile [`CUSPY_HALO_ELLIPSE_KAPPA`]
+- `Sersic_ellipse_kappa.SersicEllipseKappa`: Elliptical Sersic convergence profile [`SERSIC_ELLIPSE_KAPPA`]
 
 ## Installation
 
@@ -44,7 +47,7 @@ print(SUPPORTED_MASS_MODELS)
 ## Defining new MGE profiles
 
 If you want to use the multi-Gaussian-expansion class to create new mass profiles you will need the following:
-- The radial profile for the convergence
+- The radial profile for the mass profile divided by the critical surface density.  This can either be a 3D radial profile (e.g. useful for NFW) or the project 2D profile (e.g. useful for Sersic).
 - A subclass of the `MassModel.Profiles.MGE` class that overrides the `__init__` method to call the `MGE.__init__` with your target function
 
 As and example this is the NFWEllipseKappa profile written in this way:
@@ -53,23 +56,23 @@ As and example this is the NFWEllipseKappa profile written in this way:
 import jax.numpy as jnp
 
 from .MGE_jax import MGE
-from jax_lensing_profiles.Utility.f_function_jax import J
 
 
-def NFW_fn(r, R_s, kappa_s, **_):
+def NFW_3D_fn(r, R_s, kappa_s, **_):
     x = r / R_s
-    return 2 * kappa_s * J(x)
+    return kappa_s / (r * (1 + x)**2)
 
 
 class NFWEllipseKappa(MGE):
     def __init__(self):
         super().__init__(
-            NFW_fn,
-            'Rs',
+            NFW_3D_fn,
+            'R_s',
             n_gauss=20,
             n_terms=28,
             sigma_start_mult=1/500,
-            sigma_end_mult=20
+            sigma_end_mult=20,
+            three_d=True
         )
 ```
 

--- a/jax_lensing_profiles/MassModel/Profiles/CuspyHalo_ellipse_kappa.py
+++ b/jax_lensing_profiles/MassModel/Profiles/CuspyHalo_ellipse_kappa.py
@@ -1,5 +1,5 @@
 """This module defines a mass profile where the convergence follows 
-and elliptical NFW profile.  This makes use of the MGE profile.
+and elliptical cuspy halo profile.  This makes use of the MGE profile.
 The conventions of Keeton (2002, https://arxiv.org/pdf/astro-ph/0102341)
 are used.
 """
@@ -11,8 +11,8 @@ import jax.numpy as jnp
 from .MGE import MGE
 
 
-def NFW_3D_fn(r, R_s, kappa_s, **_):
-    '''Radial scaled mass function for a NFW profile
+def CuspyHalo_3D_fn(r, R_s, kappa_s, gamma, n, **_):
+    '''Radial scaled mass function for a cuspy halo profile
 
     Parameters
     ----------
@@ -23,21 +23,28 @@ def NFW_3D_fn(r, R_s, kappa_s, **_):
     kappa_s : float
         amplitude of the convergence.  This is related to the amplitude
         of the mass profile by rho_s = kappa_s * Critical_Surface_Density / R_s
+    gamma : float
+        logarithmic slope at small radii
+    n : float
+        logarithmic slope at large radii
 
     Returns
     -------
     float
-        scaled mass value for a 3D NFW profile
+        scaled mass value for a 3D cuspy halo profile
     '''
     x = r / R_s
-    return kappa_s / (r * (1 + x)**2)
+    t1 = x**gamma
+    power = (n - gamma) / 2
+    t2 = (1 + x**2)**power
+    return kappa_s / (R_s * t1 * t2)
 
 
 # Subclass MGE to initialize with the radial function
-class NFWEllipseKappa(MGE):
+class CuspyHaloEllipseKappa(MGE):
     def __init__(self):
         super().__init__(
-            NFW_3D_fn,
+            CuspyHalo_3D_fn,
             'R_s',
             n_gauss=20,
             n_terms=28,
@@ -48,7 +55,8 @@ class NFWEllipseKappa(MGE):
 
     # "override" these methods just to change the docstring
     def function(self, x, y, **kwargs):
-        '''Returns the lensing potential for a mass with an elliptical NFW convergence
+        '''Returns the lensing potential for a mass with an elliptical cuspy
+        halo convergence
 
         Parameters
         ----------
@@ -70,16 +78,22 @@ class NFWEllipseKappa(MGE):
             amplitude of the convergence, must be given as a keyword.
             This is related to the amplitude of the mass profile by
             rho_s = kappa_s * Critical_Surface_Density / R_s
+        gamma : float
+            logarithmic slope at small radii, must be given as a keyword
+        n : float
+            logarithmic slope at large radii, must be given as a keyword
 
         Returns
         -------
         jax.numpy.array
-            Returns the lensing potential for a mass with an elliptical NFW convergence
+            Returns the lensing potential for a mass with an elliptical cuspy
+            halo convergence
         '''
         return super().function(x, y, **kwargs)
 
     def derivatives(self, x, y, e1, e2, center_x=0, center_y=0, **kwargs):
-        '''Returns the deflection angles for a mass with an elliptical NFW convergence
+        '''Returns the deflection angles for a mass with an elliptical cuspy
+        halo convergence
 
         Parameters
         ----------
@@ -101,16 +115,22 @@ class NFWEllipseKappa(MGE):
             amplitude of the convergence, must be given as a keyword.
             This is related to the amplitude of the mass profile by
             rho_s = kappa_s * Critical_Surface_Density / R_s
+        gamma : float
+            logarithmic slope at small radii, must be given as a keyword
+        n : float
+            logarithmic slope at large radii, must be given as a keyword
 
         Returns
         -------
         jax.numpy.array
-            Returns the deflection angles for a mass with an elliptical NFW convergence
+            Returns the deflection angles for a mass with an elliptical cuspy
+            halo convergence
         '''
         return super().derivatives(x, y, e1, e2, center_x, center_y, **kwargs)
 
     def hessian(self, x, y, e1, e2, center_x=0, center_y=0, **kwargs):
-        '''Returns the hessian with respect to position for a mass with an elliptical NFW convergence
+        '''Returns the hessian with respect to position for a mass with an elliptical cuspy
+        halo convergence
 
         Parameters
         ----------
@@ -132,10 +152,15 @@ class NFWEllipseKappa(MGE):
             amplitude of the convergence, must be given as a keyword.
             This is related to the amplitude of the mass profile by
             rho_s = kappa_s * Critical_Surface_Density / R_s
+        gamma : float
+            logarithmic slope at small radii, must be given as a keyword
+        n : float
+            logarithmic slope at large radii, must be given as a keyword
 
         Returns
         -------
         jax.numpy.array
-            Returns the hessian with respect to position for a mass with an elliptical NFW convergence
+            Returns the hessian with respect to position for a mass with an elliptical cuspy
+            halo convergence
         '''
         return super().hessian(x, y, e1, e2, center_x, center_y, **kwargs)

--- a/jax_lensing_profiles/MassModel/Profiles/CuspyNFW_ellipse_kappa.py
+++ b/jax_lensing_profiles/MassModel/Profiles/CuspyNFW_ellipse_kappa.py
@@ -1,5 +1,5 @@
 """This module defines a mass profile where the convergence follows 
-and elliptical NFW profile.  This makes use of the MGE profile.
+and elliptical cuspy NFW profile.  This makes use of the MGE profile.
 The conventions of Keeton (2002, https://arxiv.org/pdf/astro-ph/0102341)
 are used.
 """
@@ -11,8 +11,8 @@ import jax.numpy as jnp
 from .MGE import MGE
 
 
-def NFW_3D_fn(r, R_s, kappa_s, **_):
-    '''Radial scaled mass function for a NFW profile
+def CuspyNFW_3D_fn(r, R_s, kappa_s, gamma, **_):
+    '''Radial scaled mass function for a cuspy NFW profile
 
     Parameters
     ----------
@@ -23,21 +23,25 @@ def NFW_3D_fn(r, R_s, kappa_s, **_):
     kappa_s : float
         amplitude of the convergence.  This is related to the amplitude
         of the mass profile by rho_s = kappa_s * Critical_Surface_Density / R_s
+    gamma : float
+        logarithmic slopes at small radii
 
     Returns
     -------
     float
-        scaled mass value for a 3D NFW profile
+        scaled mass value for a 3D cuspy NFW profile
     '''
     x = r / R_s
-    return kappa_s / (r * (1 + x)**2)
+    t1 = x**gamma
+    t2 = (1 + x)**(3 - gamma)
+    return kappa_s / (R_s * t1 * t2)
 
 
 # Subclass MGE to initialize with the radial function
-class NFWEllipseKappa(MGE):
+class CuspyNFWEllipseKappa(MGE):
     def __init__(self):
         super().__init__(
-            NFW_3D_fn,
+            CuspyNFW_3D_fn,
             'R_s',
             n_gauss=20,
             n_terms=28,
@@ -48,7 +52,8 @@ class NFWEllipseKappa(MGE):
 
     # "override" these methods just to change the docstring
     def function(self, x, y, **kwargs):
-        '''Returns the lensing potential for a mass with an elliptical NFW convergence
+        '''Returns the lensing potential for a mass with an elliptical cuspy
+        NFW convergence
 
         Parameters
         ----------
@@ -70,16 +75,20 @@ class NFWEllipseKappa(MGE):
             amplitude of the convergence, must be given as a keyword.
             This is related to the amplitude of the mass profile by
             rho_s = kappa_s * Critical_Surface_Density / R_s
+        gamma : float
+            logarithmic slope at small radii, must be given as a keyword
 
         Returns
         -------
         jax.numpy.array
-            Returns the lensing potential for a mass with an elliptical NFW convergence
+            Returns the lensing potential for a mass with an elliptical cuspy
+            NFW convergence
         '''
         return super().function(x, y, **kwargs)
 
     def derivatives(self, x, y, e1, e2, center_x=0, center_y=0, **kwargs):
-        '''Returns the deflection angles for a mass with an elliptical NFW convergence
+        '''Returns the deflection angles for a mass with an elliptical cuspy
+        NFW convergence
 
         Parameters
         ----------
@@ -101,16 +110,20 @@ class NFWEllipseKappa(MGE):
             amplitude of the convergence, must be given as a keyword.
             This is related to the amplitude of the mass profile by
             rho_s = kappa_s * Critical_Surface_Density / R_s
+        gamma : float
+            logarithmic slope at small radii, must be given as a keyword
 
         Returns
         -------
         jax.numpy.array
-            Returns the deflection angles for a mass with an elliptical NFW convergence
+            Returns the deflection angles for a mass with an elliptical cuspy
+            NFW convergence
         '''
         return super().derivatives(x, y, e1, e2, center_x, center_y, **kwargs)
 
     def hessian(self, x, y, e1, e2, center_x=0, center_y=0, **kwargs):
-        '''Returns the hessian with respect to position for a mass with an elliptical NFW convergence
+        '''Returns the hessian with respect to position for a mass with an
+        elliptical cuspy NFW convergence
 
         Parameters
         ----------
@@ -132,10 +145,13 @@ class NFWEllipseKappa(MGE):
             amplitude of the convergence, must be given as a keyword.
             This is related to the amplitude of the mass profile by
             rho_s = kappa_s * Critical_Surface_Density / R_s
+        gamma : float
+            logarithmic slope at small radii, must be given as a keyword
 
         Returns
         -------
         jax.numpy.array
-            Returns the hessian with respect to position for a mass with an elliptical NFW convergence
+            Returns the hessian with respect to position for a mass with an
+            elliptical cuspy NFW convergence
         '''
         return super().hessian(x, y, e1, e2, center_x, center_y, **kwargs)

--- a/jax_lensing_profiles/MassModel/Profiles/MGE.py
+++ b/jax_lensing_profiles/MassModel/Profiles/MGE.py
@@ -11,7 +11,7 @@ Copyright (c) 2025, herculens developers and contributors
 Copyright (c) 2018, Simon Birrer & lenstronomy contributors
 """
 
-__author__ = "ajshajib", "CKrawczyk"
+__author__ = "ajshajib", "CKrawczyk", "astroskylee"
 
 import jax
 import jax.numpy as jnp
@@ -30,7 +30,8 @@ class MGE(object):
         sigma_start_mult=1/100,
         sigma_end_mult=20.0,
         n_gauss=20,
-        n_terms=28
+        n_terms=28,
+        three_d=False
     ):
         '''Create a Multi-Gaussian Expansion for a radial convergence function
         following Shajib (2019, https://academic.oup.com/mnras/article/488/1/1387/5526256)
@@ -38,9 +39,10 @@ class MGE(object):
         Parameters
         ----------
         radial_fn : function
-            A JAX compatible function for the radial profile for the convergence
-            of the resulting expansion.  The first variable is assumed to be the radius
-            (name does not matter).
+            A JAX compatible function for the radial profile for the mass profile divided
+            by the critical surface density.  The first variable is assumed to be the radius
+            (name does not matter).  This can either be a 3D or 2D profile (use the "three_d" 
+            keyword to specify this).
         scale_name : str
             The name of the variable being used as the size scale parameter (e.g. "
             effective_radius" or "Rs").
@@ -56,8 +58,13 @@ class MGE(object):
             The number of terms used for the inverse transform (called P in Shajib 2019).
             This value should be set based on what floating-point precision is being used,
             if using 32-bit set to ~13, if using 64-bit set to ~28, by default 28.
+        three_d : bool, optional
+            Set this keyword to True if the radial profile is for the 3D mass density function,
+            otherwise the radial profile should be for the project 2D mass density function.
+            By default False.
         '''
         self.radial_fn = radial_fn
+        self.three_d = three_d
         self.n_gauss = n_gauss
         self.scale_name = scale_name
         self.sigma_start_mult = sigma_start_mult
@@ -113,7 +120,10 @@ class MGE(object):
             ),
             axis=1
         )
-        amps = self.w * f_eval * d_log_sigma / self.root_two_pi
+        if self.three_d:
+            amps = self.w * f_eval * d_log_sigma * sigmas
+        else:
+            amps = self.w * f_eval * d_log_sigma / self.root_two_pi
         return amps, sigmas
 
     @staticmethod

--- a/jax_lensing_profiles/MassModel/Profiles/NFW.py
+++ b/jax_lensing_profiles/MassModel/Profiles/NFW.py
@@ -151,7 +151,9 @@ class NFW(NFWBase):
         center_y : float, keyword
             center of the profile, must be given as a keyword
         kappa_s : float, keyword
-            amplitude of the convergence, must be given as a keyword
+            amplitude of the convergence, must be given as a keyword.
+            This is related to the amplitude of the mass profile by
+            rho_s = kappa_s * Critical_Surface_Density / R_s
         R_s : float, keyword
             scale radius, must be given as a keyword
 
@@ -176,7 +178,9 @@ class NFW(NFWBase):
         center_y : float, keyword
             center of the profile, must be given as a keyword
         kappa_s : float, keyword
-            amplitude of the convergence, must be given as a keyword
+            amplitude of the convergence, must be given as a keyword.
+            This is related to the amplitude of the mass profile by
+            rho_s = kappa_s * Critical_Surface_Density / R_s
         R_s : float, keyword
             scale radius, must be given as a keyword
 
@@ -201,7 +205,9 @@ class NFW(NFWBase):
         center_y : float, keyword
             center of the profile, must be given as a keyword
         kappa_s : float, keyword
-            amplitude of the convergence, must be given as a keyword
+            amplitude of the convergence, must be given as a keyword.
+            This is related to the amplitude of the mass profile by
+            rho_s = kappa_s * Critical_Surface_Density / R_s
         R_s : float, keyword
             scale radius, must be given as a keyword
 
@@ -319,7 +325,9 @@ class TNFW(NFWBase):
         center_y : float, keyword
             center of the profile, must be given as a keyword
         kappa_s : float, keyword
-            amplitude of the convergence, must be given as a keyword
+            amplitude of the convergence, must be given as a keyword.
+            This is related to the amplitude of the mass profile by
+            rho_s = kappa_s * Critical_Surface_Density / R_s
         R_s : float, keyword
             scale radius, must be given as a keyword
         R_t : float, keyword
@@ -346,7 +354,9 @@ class TNFW(NFWBase):
         center_y : float, keyword
             center of the profile, must be given as a keyword
         kappa_s : float, keyword
-            amplitude of the convergence, must be given as a keyword
+            amplitude of the convergence, must be given as a keyword.
+            This is related to the amplitude of the mass profile by
+            rho_s = kappa_s * Critical_Surface_Density / R_s
         R_s : float, keyword
             scale radius, must be given as a keyword
         R_t : float, keyword
@@ -373,7 +383,9 @@ class TNFW(NFWBase):
         center_y : float, keyword
             center of the profile, must be given as a keyword
         kappa_s : float, keyword
-            amplitude of the convergence, must be given as a keyword
+            amplitude of the convergence, must be given as a keyword.
+            This is related to the amplitude of the mass profile by
+            rho_s = kappa_s * Critical_Surface_Density / R_s
         R_s : float, keyword
             scale radius, must be given as a keyword
         R_t : float, keyword

--- a/jax_lensing_profiles/MassModel/Profiles/TNFW_ellipse_kappa.py
+++ b/jax_lensing_profiles/MassModel/Profiles/TNFW_ellipse_kappa.py
@@ -1,7 +1,7 @@
 """This module defines a mass profile where the convergence follows 
-and elliptical NFW profile.  This makes use of the MGE profile.
+and truncated NFW profile.  This makes use of the MGE profile.
 The conventions of Keeton (2002, https://arxiv.org/pdf/astro-ph/0102341)
-are used.
+are used and the profile is take from Oguri (2011, https://arxiv.org/pdf/1101.0650)
 """
 
 __author__ = "WolfgangEnzi", "CKrawczyk", "astroskylee"
@@ -11,8 +11,8 @@ import jax.numpy as jnp
 from .MGE import MGE
 
 
-def NFW_3D_fn(r, R_s, kappa_s, **_):
-    '''Radial scaled mass function for a NFW profile
+def TNFW_3D_fn(r, R_s, kappa_s, R_t, n, **_):
+    '''Radial scaled mass function for a truncated NFW profile
 
     Parameters
     ----------
@@ -23,21 +23,27 @@ def NFW_3D_fn(r, R_s, kappa_s, **_):
     kappa_s : float
         amplitude of the convergence.  This is related to the amplitude
         of the mass profile by rho_s = kappa_s * Critical_Surface_Density / R_s
+    R_t : float
+        truncation radius
+    n : float
+        truncation slope
 
     Returns
     -------
     float
-        scaled mass value for a 3D NFW profile
+        scaled mass value for a 3D truncated NFW profile
     '''
+    tau = R_t / R_s
     x = r / R_s
-    return kappa_s / (r * (1 + x)**2)
+    t = (tau**2 / (x**2 + tau**2))**n
+    return kappa_s * t / (r * (1 + x)**2)
 
 
 # Subclass MGE to initialize with the radial function
-class NFWEllipseKappa(MGE):
+class TNFWEllipseKappa(MGE):
     def __init__(self):
         super().__init__(
-            NFW_3D_fn,
+            TNFW_3D_fn,
             'R_s',
             n_gauss=20,
             n_terms=28,
@@ -48,7 +54,8 @@ class NFWEllipseKappa(MGE):
 
     # "override" these methods just to change the docstring
     def function(self, x, y, **kwargs):
-        '''Returns the lensing potential for a mass with an elliptical NFW convergence
+        '''Returns the lensing potential for a mass with an elliptical truncated
+        NFW convergence
 
         Parameters
         ----------
@@ -70,16 +77,22 @@ class NFWEllipseKappa(MGE):
             amplitude of the convergence, must be given as a keyword.
             This is related to the amplitude of the mass profile by
             rho_s = kappa_s * Critical_Surface_Density / R_s
+        R_t : float
+            truncation radius, must be given as a keyword
+        n : float
+            truncation slope, must be given as a keyword
 
         Returns
         -------
         jax.numpy.array
-            Returns the lensing potential for a mass with an elliptical NFW convergence
+            Returns the lensing potential for a mass with an elliptical truncated
+            NFW convergence
         '''
         return super().function(x, y, **kwargs)
 
     def derivatives(self, x, y, e1, e2, center_x=0, center_y=0, **kwargs):
-        '''Returns the deflection angles for a mass with an elliptical NFW convergence
+        '''Returns the deflection angles for a mass with an elliptical truncated
+        NFW convergence
 
         Parameters
         ----------
@@ -101,16 +114,22 @@ class NFWEllipseKappa(MGE):
             amplitude of the convergence, must be given as a keyword.
             This is related to the amplitude of the mass profile by
             rho_s = kappa_s * Critical_Surface_Density / R_s
+        R_t : float
+            truncation radius, must be given as a keyword
+        n : float
+            truncation slope, must be given as a keyword
 
         Returns
         -------
         jax.numpy.array
-            Returns the deflection angles for a mass with an elliptical NFW convergence
+            Returns the deflection angles for a mass with an elliptical truncated
+            NFW convergence
         '''
         return super().derivatives(x, y, e1, e2, center_x, center_y, **kwargs)
 
     def hessian(self, x, y, e1, e2, center_x=0, center_y=0, **kwargs):
-        '''Returns the hessian with respect to position for a mass with an elliptical NFW convergence
+        '''Returns the hessian with respect to position for a mass with an
+        elliptical truncated NFW convergence
 
         Parameters
         ----------
@@ -132,10 +151,15 @@ class NFWEllipseKappa(MGE):
             amplitude of the convergence, must be given as a keyword.
             This is related to the amplitude of the mass profile by
             rho_s = kappa_s * Critical_Surface_Density / R_s
+        R_t : float
+            truncation radius, must be given as a keyword
+        n : float
+            truncation slope, must be given as a keyword
 
         Returns
         -------
         jax.numpy.array
-            Returns the hessian with respect to position for a mass with an elliptical NFW convergence
+            Returns the hessian with respect to position for a mass with an
+            elliptical truncated NFW convergence
         '''
         return super().hessian(x, y, e1, e2, center_x, center_y, **kwargs)

--- a/jax_lensing_profiles/MassModel/Profiles/__init__.py
+++ b/jax_lensing_profiles/MassModel/Profiles/__init__.py
@@ -5,4 +5,7 @@ from .multi_gaussian_ellipse_kappa import MultiGaussianEllipseKappa
 from .NFW import NFW
 from .NFW import TNFW
 from .NFW_ellipse_kappa import NFWEllipseKappa
+from .CuspyNFW_ellipse_kappa import CuspyNFWEllipseKappa
+from .CuspyHalo_ellipse_kappa import CuspyHaloEllipseKappa
+from .TNFW_ellipse_kappa import TNFWEllipseKappa
 from .Sersic_ellipse_kappa import SersicEllipseKappa

--- a/jax_lensing_profiles/__init__.py
+++ b/jax_lensing_profiles/__init__.py
@@ -4,7 +4,7 @@ from . import LightModel
 from . import MassModel
 from . import Utility
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 
 
 # Register the new mass and light profiles with herculens on import
@@ -23,5 +23,8 @@ mass_model_base.STRING_MAPPING['MGE'] = MassModel.Profiles.MGE
 mass_model_base.STRING_MAPPING['NFW'] = MassModel.Profiles.NFW
 mass_model_base.STRING_MAPPING['TNFW'] = MassModel.Profiles.TNFW
 mass_model_base.STRING_MAPPING['NFW_ELLIPSE_KAPPA'] = MassModel.Profiles.NFWEllipseKappa
+mass_model_base.STRING_MAPPING['TNFW_ELLIPSE_KAPPA'] = MassModel.Profiles.TNFWEllipseKappa
+mass_model_base.STRING_MAPPING['CUSPY_NFW_ELLIPSE_KAPPA'] = MassModel.Profiles.CuspyNFWEllipseKappa
+mass_model_base.STRING_MAPPING['CUSPY_HALO_ELLIPSE_KAPPA'] = MassModel.Profiles.CuspyHaloEllipseKappa
 mass_model_base.STRING_MAPPING['SERSIC_ELLIPSE_KAPPA'] = MassModel.Profiles.SersicEllipseKappa
 mass_model_base.SUPPORTED_MODELS = list(mass_model_base.STRING_MAPPING.keys())


### PR DESCRIPTION
Turns out a very simple modification can be made to the MGE code to allow it to take in a 3D radial mass profile rather than a projected 2D mass profile.  If the 3D profile is decomposed in the typical way, the 2D project is trivial to compute since the project of each gaussian is just another gaussian with its amplitude scaled by `sqrt(2*pi)*sigma`.

If the `tree_d` keyword is set in the MGE, it will add this factor and proceed as normal. This enables the family of NFW profiles to be coded up far easier, as they all have easy-to-write 3D profiles (and typically non-analytic 2D projections).

To leverage this new ability, the NFW_ellipse_kappa profile has been written with far less (and far easier to read) code. Alongside this, the truncated NFW, cuspy NFW, and cuspy halo mass models have also been included. The last two are both called "generalized NFW profiles", depending on the paper. I went with the Keeton 2002 names to try and avoid confusion.