### PR TITLE
Use log-segmented quadrature for MGE lens potentials

### DIFF
--- a/jax_lensing_profiles/MassModel/Profiles/MGE.py
+++ b/jax_lensing_profiles/MassModel/Profiles/MGE.py
@@ -17,7 +17,9 @@ import jax
 import jax.numpy as jnp
 import herculens.Util.param_util as param_util
 
-from jax_lensing_profiles.Utility.basic_quad_jax import nth_order_quad_base as quad
+from jax_lensing_profiles.Utility.basic_quad_jax import (
+    log_segmented_nth_order_quad_base as quad,
+)
 from jax_lensing_profiles.Utility.faddeeva_function import w_f
 from functools import partial
 
@@ -235,13 +237,17 @@ class MGE(object):
             MGE.pot_real_line_integrand,
             0, x_,
             args=(_p, q),
-            n=7
+            n=7,
+            segments=8,
+            log_L=3.0,
         )
         pot_on_imag_parallel = quad(
             MGE.pot_imag_line_integrand,
             0, y_,
             args=(x_, _p, q),
-            n=7
+            n=7,
+            segments=8,
+            log_L=3.0,
         )
         return factor * (pot_on_real_line - pot_on_imag_parallel)
 

--- a/jax_lensing_profiles/MassModel/Profiles/multi_gaussian_ellipse_kappa.py
+++ b/jax_lensing_profiles/MassModel/Profiles/multi_gaussian_ellipse_kappa.py
@@ -16,7 +16,9 @@ import jax
 import jax.numpy as jnp
 import herculens.Util.param_util as param_util
 
-from jax_lensing_profiles.Utility.basic_quad_jax import nth_order_quad_base as quad
+from jax_lensing_profiles.Utility.basic_quad_jax import (
+    log_segmented_nth_order_quad_base as quad,
+)
 from jax_lensing_profiles.Utility.faddeeva_function import w_f
 from jax.tree_util import Partial as partial
 
@@ -150,13 +152,17 @@ class MultiGaussianEllipseKappa(object):
             MultiGaussianEllipseKappa.pot_real_line_integrand,
             0, x_,
             args=(_p, q),
-            n=7
+            n=7,
+            segments=8,
+            log_L=3.0,
         )
         pot_on_imag_parallel = quad(
             MultiGaussianEllipseKappa.pot_imag_line_integrand,
             0, y_,
             args=(x_, _p, q),
-            n=7
+            n=7,
+            segments=8,
+            log_L=3.0,
         )
         return factor * (pot_on_real_line - pot_on_imag_parallel)
 

--- a/jax_lensing_profiles/Utility/basic_quad_jax.py
+++ b/jax_lensing_profiles/Utility/basic_quad_jax.py
@@ -49,6 +49,73 @@ def nth_order_quad_base(func, a, b, args=(), kwargs={}, n=21):
 nth_order_quad = jax.jit(nth_order_quad_base, static_argnums=(0, 5))
 
 
+def log_segmented_nth_order_quad_base(
+    func,
+    a,
+    b,
+    args=(),
+    kwargs={},
+    n=21,
+    segments=8,
+    log_L=3.0,
+):
+    '''Nth order Gauss-Legendre quadrature on log-spaced sub-intervals
+
+    Parameters
+    ----------
+    func : function
+        function to integrate
+    a : float
+        lower bound of integration
+    b : float
+        upper bound of integration
+    args : tuple, optional
+        positional arguments of input function, by default ()
+    kwargs : dict, optional
+        keywords of input function, by default {}
+    n : int, optional
+        order of legendre roots to use on each segment, by default 21
+    segments : int, optional
+        number of log-spaced segments, by default 8
+    log_L : float, optional
+        decade span controlling the lower-edge clustering, by default 3.0
+
+    Returns
+    -------
+    float
+        the segmented integration of the input function between `a` and `b`
+    '''
+    roots = jnp.array(roots_legendre(n)).T
+    x_val = roots[:, 0]
+    weights = roots[:, 1]
+
+    u = jnp.logspace(-log_L, 0.0, segments + 1)
+    edges = a + (b - a) * (u - u[0]) / (u[-1] - u[0])
+    left, right = edges[:-1], edges[1:]
+
+    x = 0.5 * ((right - left)[:, None] * x_val[None, :] + (right + left)[:, None])
+    x_flat = x.reshape(-1, 1)
+
+    aux = jnp.apply_along_axis(
+        func,
+        1,
+        x_flat,
+        *args,
+        **kwargs
+    )
+    scale = 0.5 * (right - left)
+    aux = aux.reshape((segments, n) + aux.shape[1:])
+    weighted = jnp.tensordot(aux, weights, axes=([1], [0]))
+    seg_int = weighted * scale.reshape((segments,) + (1,) * (weighted.ndim - 1))
+    return jnp.squeeze(jnp.sum(seg_int, axis=0))
+
+
+log_segmented_nth_order_quad = jax.jit(
+    log_segmented_nth_order_quad_base,
+    static_argnums=(0, 5, 6, 7),
+)
+
+
 @partial(jax.jit, static_argnums=(0, 5))
 def vec_nth_order_quad(func, a, b, args=(), kwargs={}, n=21):
     '''Nth order Gauss-Legendre quadrature vectorized over the bounds

--- a/jax_lensing_profiles/Utility/basic_quad_jax.py
+++ b/jax_lensing_profiles/Utility/basic_quad_jax.py
@@ -78,7 +78,9 @@ def log_segmented_nth_order_quad_base(
     segments : int, optional
         number of log-spaced segments, by default 8
     log_L : float, optional
-        decade span controlling the lower-edge clustering, by default 3.0
+        Starting point of the logarithmic segmentation, e.g. log_L = 3 means
+        the segment edges are built from np.logspace(-3, 0) before rescaling
+        to [a, b], by default 3.0
 
     Returns
     -------


### PR DESCRIPTION
Summary
- add a log-segmented Gauss-Legendre quadrature helper
- use the segmented quadrature in the lens-potential integrals of `MultiGaussianEllipseKappa`
- use the segmented quadrature in the lens-potential integrals of `MGE`
- 
Relative difference (lenstronomy MGE) of MGE mass model of EPL profile:

model                           dpsi                   FPD                   |FPD-len|           rel[%]
EPL                        0.309994111   -0.498213976 1.043470671e-03     0.209882
lenstronomy         0.308950640   -0.497170505 0.000000000e+00     0.000000
JLP normal            0.309223468   -0.497443333 2.728279527e-04     0.054876
JLP segmented     0.308950906   -0.497170771 2.659581425e-07     0.000053

Lenstronomy and JLP use the same MGE amplitude and sigma